### PR TITLE
feat: support TypeScript v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,9 +32,9 @@
     "js-yaml": "^4.1.0"
   },
   "devDependencies": {
-    "@types/js-yaml": "^4.0.5",
-    "@types/node": "^18.15.3",
-    "typescript": "^4.9.5"
+    "@types/js-yaml": "^4.0.9",
+    "@types/node": "^22.5.0",
+    "typescript": "^5.5.4"
   },
   "prettier": {
     "singleQuote": true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,27 +1,29 @@
-lockfileVersion: 5.4
+lockfileVersion: 5.3
 
 specifiers:
-  '@types/js-yaml': ^4.0.5
-  '@types/node': ^18.15.3
+  '@types/js-yaml': ^4.0.9
+  '@types/node': ^22.5.0
   js-yaml: ^4.1.0
-  typescript: ^4.9.5
+  typescript: ^5.5.4
 
 dependencies:
   js-yaml: 4.1.0
 
 devDependencies:
-  '@types/js-yaml': 4.0.5
-  '@types/node': 18.15.3
-  typescript: 4.9.5
+  '@types/js-yaml': 4.0.9
+  '@types/node': 22.5.0
+  typescript: 5.5.4
 
 packages:
 
-  /@types/js-yaml/4.0.5:
-    resolution: {integrity: sha512-FhpRzf927MNQdRZP0J5DLIdTXhjLYzeUTmLAu69mnVksLH9CJY3IuSeEgbKUki7GQZm0WqDkGzyxju2EZGD2wA==}
+  /@types/js-yaml/4.0.9:
+    resolution: {integrity: sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==}
     dev: true
 
-  /@types/node/18.15.3:
-    resolution: {integrity: sha512-p6ua9zBxz5otCmbpb5D3U4B5Nanw6Pk3PPyX05xnxbB/fRv71N7CPmORg7uAD5P70T0xmx1pzAx/FUfa5X+3cw==}
+  /@types/node/22.5.0:
+    resolution: {integrity: sha512-DkFrJOe+rfdHTqqMg0bSNlGlQ85hSoh2TPzZyhHsXnMtligRWpxUySiyw8FY14ITt24HVCiQPWxS3KO/QlGmWg==}
+    dependencies:
+      undici-types: 6.19.8
     dev: true
 
   /argparse/2.0.1:
@@ -35,8 +37,12 @@ packages:
       argparse: 2.0.1
     dev: false
 
-  /typescript/4.9.5:
-    resolution: {integrity: sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==}
-    engines: {node: '>=4.2.0'}
+  /typescript/5.5.4:
+    resolution: {integrity: sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==}
+    engines: {node: '>=14.17'}
     hasBin: true
+    dev: true
+
+  /undici-types/6.19.8:
+    resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
     dev: true


### PR DESCRIPTION
There was a breaking change in the plugin interface. Code is refactored to support both v4 and v5. I've only tested v5.5.3 here, but the refactor is heavily borrowed from https://github.com/mrmckeb/typescript-plugin-css-modules

Closes #1